### PR TITLE
ADD custom webpack.config.js in bundles

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
+++ b/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
@@ -15,8 +15,11 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EzSystemsEzPlatformEncoreExtension extends Extension
 {
-    const EZ_ENCORE_CONFIG_NAME = 'ez.config.js';
-    const EZ_ENCORE_MANAGER_NAME = 'ez.config.manager.js';
+    const CONFIGS_NAME = [
+        'ez.config.js',
+        'ez.config.manager.js',
+        'webpack.config.js',
+    ];
 
     /**
      * {@inheritdoc}
@@ -24,22 +27,24 @@ class EzSystemsEzPlatformEncoreExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
-        $rootPath = dirname($container->getParameter('kernel.root_dir'));
+        $rootPath = \dirname($container->getParameter('kernel.root_dir'));
         $targetPath = 'var/encore';
 
-        $this->dumpConfigurationPathsToFile($rootPath, $targetPath, $bundlesMetadata);
-        $this->dumpConfigurationManagerPathsToFile($rootPath, $targetPath, $bundlesMetadata);
+        foreach (self::CONFIGS_NAME as $configName) {
+            $this->dumpConfigurationPathsToFile($configName, $rootPath, $targetPath, $bundlesMetadata);
+        }
     }
 
     /**
-     * Looks for Resources/encore/ez.config.js file in every registered and enabled bundle.
+     * Looks for Resources/encore/ files in every registered and enabled bundle.
      * Dumps json list of paths to files it finds.
      *
+     * @param string $configName
      * @param string $rootPath
-     * @param string $targetPath Where to put eZ Encore paths configuration file (default: var/encore/ez.config.js)
+     * @param string $targetPath Where to put eZ Encore paths configuration file (default: var/encore)
      * @param array $bundlesMetadata
      */
-    public function dumpConfigurationPathsToFile(string $rootPath, string $targetPath, array $bundlesMetadata): void
+    public function dumpConfigurationPathsToFile(string $configName, string $rootPath, string $targetPath, array $bundlesMetadata): void
     {
         $finder = new Finder();
         $filesystem = new Filesystem();
@@ -48,7 +53,7 @@ class EzSystemsEzPlatformEncoreExtension extends Extension
         $finder
             ->in(array_column($bundlesMetadata, 'path'))
             ->path('Resources/encore')
-            ->name(self::EZ_ENCORE_CONFIG_NAME)
+            ->name($configName)
             ->files();
 
         /** @var \Symfony\Component\Finder\SplFileInfo $fileInfo */
@@ -62,43 +67,7 @@ class EzSystemsEzPlatformEncoreExtension extends Extension
 
         $filesystem->mkdir($targetPath);
         $filesystem->dumpFile(
-            $rootPath . '/' . $targetPath . '/' . self::EZ_ENCORE_CONFIG_NAME,
-            sprintf('module.exports = %s;', json_encode($paths))
-        );
-    }
-
-    /**
-     * Looks for Resources/encore/ez.config.manager.js file in every registered and enabled bundle.
-     * Dumps json list of paths to files it finds.
-     *
-     * @param string $rootPath
-     * @param string $targetPath Where to put eZ Encore paths manager file (default: var/encore/ez.config.manager.js)
-     * @param array $bundlesMetadata
-     */
-    public function dumpConfigurationManagerPathsToFile(string $rootPath, string $targetPath, array $bundlesMetadata): void
-    {
-        $finder = new Finder();
-        $filesystem = new Filesystem();
-        $paths = [];
-
-        $finder
-            ->in(array_column($bundlesMetadata, 'path'))
-            ->path('Resources/encore')
-            ->name(self::EZ_ENCORE_MANAGER_NAME)
-            ->files();
-
-        /** @var \Symfony\Component\Finder\SplFileInfo $fileInfo */
-        foreach ($finder as $fileInfo) {
-            $paths[] = preg_replace(
-                '/^' . preg_quote($rootPath, '/') . '/',
-                '.',
-                $fileInfo->getRealPath()
-            );
-        }
-
-        $filesystem->mkdir($targetPath);
-        $filesystem->dumpFile(
-            $rootPath . '/' . $targetPath . '/' . self::EZ_ENCORE_MANAGER_NAME,
+            $rootPath . '/' . $targetPath . '/' . $configName,
             sprintf('module.exports = %s;', json_encode($paths))
         );
     }

--- a/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
+++ b/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EzSystemsEzPlatformEncoreExtension extends Extension
 {
-    const CONFIGS_NAME = [
+    const CONFIG_NAMES = [
         'ez.config.js',
         'ez.config.manager.js',
-        'webpack.config.js',
+        'ez.webpack.config.js',
     ];
 
     /**

--- a/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
+++ b/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
@@ -18,7 +18,7 @@ class EzSystemsEzPlatformEncoreExtension extends Extension
     const CONFIG_NAMES = [
         'ez.config.js',
         'ez.config.manager.js',
-        'ez.webpack.config.js',
+        'ez.webpack.custom.config.js',
     ];
 
     /**

--- a/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
+++ b/src/EzPlatformEncoreBundle/bundle/DependencyInjection/EzSystemsEzPlatformEncoreExtension.php
@@ -30,7 +30,7 @@ class EzSystemsEzPlatformEncoreExtension extends Extension
         $rootPath = \dirname($container->getParameter('kernel.root_dir')) . '/';
         $targetPath = 'var/encore';
 
-        foreach (self::CONFIGS_NAME as $configName) {
+        foreach (self::CONFIG_NAMES as $configName) {
             $this->dumpConfigurationPathsToFile($configName, $rootPath, $targetPath, $bundlesMetadata);
         }
     }


### PR DESCRIPTION
## Pull Request

Give possibility to users and bundles creator to have a custom webpack.config.js for Encore.

## Motivation

In production we have React with SSR and we need to fully customize Encore configuration.
In EzPlatform there is a possibility :

``` js
Encore.reset();
Encore.setOutputPath('web/assets/build')
    .setPublicPath('/assets/build')
    .enableSassLoader()
    .enableReactPreset()
    .enableSingleRuntimeChunk();

// Put your config here.

// uncomment the two lines below, if you added a new entry (by Encore.addEntry() or Encore.addStyleEntry() method) to your own Encore configuration for your project
// const projectConfig = Encore.getWebpackConfig();
// module.exports = [ eZConfig, projectConfig ];

// comment-out this line if you've uncommented the above lines
module.exports = eZConfig;
```
But... this seems pretty cheap and there no options for bundles that need custom config with customs namespaces in twig files to use **encore_entry_script_tags**

## Proposal

Add a **webpack.config.js** file in **/var/webpack** that list all custom configs.

Users can edit the root **webpack.config.js** or **ez.webpack.config.js** to use this generated file.

## Example

Manage customs single or multiple configs exports.

``` diff
+ const webpackConfigs = require('./var/encore/webpack.config.js');
//
- return eZConfig;
+ return webpackConfigs.reduce((configs, configPath) => {
        const config = require(configPath)
        return Array.isArray(config)
            ? [...configs, ...config]
            : [...configs, config]
    }, [eZConfig]);
```