### PR TITLE
EZP-30479: Compile assets script is not working on some setups

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -16,10 +16,12 @@ use Symfony\Component\Process\Process;
 
 class CompileAssetsCommand extends ContainerAwareCommand
 {
+    public const COMMAND_NAME = 'ezplatform:encore:compile';
+
     protected function configure(): void
     {
         $this
-            ->setName('ezplatform:encore:compile')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Compiles all assets using WebPack Encore')
             ->addOption(
                 'timeout',

--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformEncoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class CompileAssetsCommand extends ContainerAwareCommand
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('ezplatform:encore:compile')
+            ->setDescription('Compiles all assets using WebPack Encore')
+            ->addOption(
+                'timeout',
+                't',
+                InputOption::VALUE_OPTIONAL,
+                'Timeout in seconds',
+                300
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $timeout = $input->getOption('timeout');
+        $env = $input->getOption('env');
+
+        $output->writeln(sprintf('Compiling all <comment>%s</comment> assets.', $env));
+        $output->writeln('');
+
+        $encoreEnv = $env === 'prod' ? 'prod' : 'dev';
+        $yarnEncoreCommand = "yarn encore {$encoreEnv}";
+
+        $debugFormatter = $this->getHelper('debug_formatter');
+
+        $process = new Process(
+            $yarnEncoreCommand,
+            null,
+            null,
+            null,
+            $timeout
+        );
+
+        $output->writeln($debugFormatter->start(
+            spl_object_hash($process),
+            sprintf('Evaluating command <comment>%s</comment>', $yarnEncoreCommand)
+        ));
+
+        $process->run(function ($type, $buffer) use ($output, $debugFormatter, $process) {
+            $output->write(
+                $debugFormatter->progress(
+                    spl_object_hash($process),
+                    $buffer,
+                    Process::ERR === $type
+                )
+            );
+        });
+
+        $output->writeln(
+            $debugFormatter->stop(
+                spl_object_hash($process),
+                'Command finished',
+                $process->isSuccessful()
+            )
+        );
+    }
+}

--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformEncoreBundle\Command;
 
+use InvalidArgumentException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -29,8 +30,16 @@ class CompileAssetsCommand extends ContainerAwareCommand
                 InputOption::VALUE_OPTIONAL,
                 'Timeout in seconds',
                 300
-            )
-        ;
+            );
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $timeout = $input->getOption('timeout');
+
+        if (!is_numeric($timeout)) {
+            throw new InvalidArgumentException('Timeout value has to be an integer.');
+        }
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): void

--- a/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
+++ b/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformEncoreBundle\Composer;
 
 use Composer\Script\Event;
+use EzSystems\EzPlatformEncoreBundle\Command\CompileAssetsCommand;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -21,8 +22,6 @@ use Composer\Util\ProcessExecutor;
  */
 class ScriptHandler
 {
-    public const EZPLATFORM_ENCORE_COMPILE_CMD_NAME = 'ezplatform:encore:compile';
-
     /**
      * @param \Composer\Script\Event $event
      */
@@ -43,7 +42,7 @@ class ScriptHandler
         }
 
         $process = new Process(
-            "{$php} {$console} " . self::EZPLATFORM_ENCORE_COMPILE_CMD_NAME,
+            "{$php} {$console} " . CompileAssetsCommand::COMMAND_NAME,
             null,
             null,
             null,
@@ -56,7 +55,7 @@ class ScriptHandler
         if (!$process->isSuccessful()) {
             throw new RuntimeException(sprintf(
                 "An error occurred when executing the \"%s\" command:\n\n%s\n\n%s",
-                ProcessExecutor::escape(self::EZPLATFORM_ENCORE_COMPILE_CMD_NAME),
+                ProcessExecutor::escape(CompileAssetsCommand::COMMAND_NAME),
                 self::removeDecoration($process->getOutput()),
                 self::removeDecoration($process->getErrorOutput()))
             );

--- a/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
+++ b/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformEncoreBundle\Composer;
+
+use Composer\Script\Event;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Composer\Util\ProcessExecutor;
+
+/**
+ * Runs assets compilation command in separate process.
+ *
+ * Code is adapted from {@see \Sensio\Bundle\DistributionBundle\Composer\ScriptHandler}.
+ */
+class ScriptHandler
+{
+    public const EZPLATFORM_ENCORE_COMPILE_CMD_NAME = 'ezplatform:encore:compile';
+
+    /**
+     * @param \Composer\Script\Event $event
+     */
+    public static function compileAssets(Event $event): void
+    {
+        $options = $event->getComposer()->getPackage()->getExtra();
+        $symfonyBinDir = $options['symfony-bin-dir'];
+        $timeout = $event->getComposer()->getConfig()->get('process-timout');
+
+        $php = ProcessExecutor::escape(self::getPhpExecutable());
+        $console = ProcessExecutor::escape("{$symfonyBinDir}/console");
+        if ($event->getIO()->isDecorated()) {
+            $console .= ' --ansi';
+        }
+
+        if (!$event->isDevMode()) {
+            $console .= ' --env=prod';
+        }
+
+        $process = new Process(
+            "{$php} {$console} " . self::EZPLATFORM_ENCORE_COMPILE_CMD_NAME,
+            null,
+            null,
+            null,
+            $timeout
+        );
+        $process->run(function ($type, $buffer) use ($event) {
+            $event->getIO()->write($buffer, false);
+        });
+
+        if (!$process->isSuccessful()) {
+            throw new RuntimeException(sprintf(
+                "An error occurred when executing the \"%s\" command:\n\n%s\n\n%s",
+                ProcessExecutor::escape(self::EZPLATFORM_ENCORE_COMPILE_CMD_NAME),
+                self::removeDecoration($process->getOutput()),
+                self::removeDecoration($process->getErrorOutput()))
+            );
+        }
+    }
+
+    private static function removeDecoration(string $text): string
+    {
+        return preg_replace("/\033\[[^m]*m/", '', $text);
+    }
+
+    private static function getPhpExecutable(): string
+    {
+        $phpFinder = new PhpExecutableFinder();
+        if (!$phpPath = $phpFinder->find(false)) {
+            throw new RuntimeException('The php executable could not be found, add it to your PATH environment variable and try again');
+        }
+
+        return $phpPath;
+    }
+}

--- a/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
+++ b/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
@@ -37,10 +37,6 @@ class ScriptHandler
             $console .= ' --ansi';
         }
 
-        if (!$event->isDevMode()) {
-            $console .= ' --env=prod';
-        }
-
         $process = new Process(
             "{$php} {$console} " . CompileAssetsCommand::COMMAND_NAME,
             null,


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30479
> Related PR: https://github.com/ezsystems/ezplatform/pull/393

# Description
This PR adds two things:
* `ezplatform:encore:compile` console command - it takes application env and decides on parameters it should run encore with. For `prod` environment it will use `yarn encore prod`, in other cases `yarn encore dev`. It has additional `--timeout|-t` option to provide timeout for process execution. It's `300 seconds` by default.
* `EzSystems\EzPlatformEncoreBundle\Composer\ScriptHandler::compileAssets` composer handler running on `post-install-cmd` and `post-update-cmd` to call above `ezplatform:encore:compile`.