### PR TITLE
Dump translations before compiling assets

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
+++ b/src/EzPlatformEncoreBundle/bundle/Composer/ScriptHandler.php
@@ -38,12 +38,28 @@ class ScriptHandler
         }
 
         $process = new Process(
+            "{$php} {$console} bazinga:js-translation:dump web/assets --merge-domains",
+            null,
+            null,
+            null,
+            $timeout
+        );
+
+        $this->runProcess($event, $process, "bazinga:js-translation:dump");
+
+        $process = new Process(
             "{$php} {$console} " . CompileAssetsCommand::COMMAND_NAME,
             null,
             null,
             null,
             $timeout
         );
+
+        $this->runProcess($event, $process, CompileAssetsCommand::COMMAND_NAME);
+    }
+
+    private function runProcess(Event $event, Process $process, string $commandName): void
+    {
         $process->run(function ($type, $buffer) use ($event) {
             $event->getIO()->write($buffer, false);
         });
@@ -51,7 +67,7 @@ class ScriptHandler
         if (!$process->isSuccessful()) {
             throw new RuntimeException(sprintf(
                 "An error occurred when executing the \"%s\" command:\n\n%s\n\n%s",
-                ProcessExecutor::escape(CompileAssetsCommand::COMMAND_NAME),
+                ProcessExecutor::escape($commandName),
                 self::removeDecoration($process->getOutput()),
                 self::removeDecoration($process->getErrorOutput()))
             );


### PR DESCRIPTION
Since compiling assets depends on javascript translations being present, this moves the dumping command from `composer.json` to Composer script.

This makes it possible to run the script by hand if needed, without risking translations not being present in compiled output, if e.g. web/assets folder was deleted by hand.

Depends on https://github.com/ezsystems/ezplatform/pull/394