### PR TITLE
EZP-30636: Provided forward compatibility for eZ Platform Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
           php: '7.3'
           script:
               - composer fix-cs
+        - name: 'Unit tests'
+          php: '7.3'
+          script:
+              - composer test
 
 notifications:
     slack:

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
             "EzSystems\\EzPlatformEncoreBundle\\": "src/EzPlatformEncoreBundle/bundle/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "EzSystems\\Tests\\EzPlatformCoreBundle\\": "tests/EzPlatformCoreBundle/bundle/"
+        }
+    },
     "require": {
         "php": "^7.1",
         "symfony/symfony": "^3.4"

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^8.3.5"
     },
     "scripts": {
+        "test": "phpunit -v -c phpunit.xml",
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "autoload": {
         "psr-4": {
+            "EzSystems\\EzPlatformCoreBundle\\": "src/EzPlatformCoreBundle/bundle/",
             "EzSystems\\EzPlatformEncoreBundle\\": "src/EzPlatformEncoreBundle/bundle/"
         }
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,4 +10,7 @@
   <php>
     <ini name="error_reporting" value="-1" />
   </php>
+  <testsuite name="EzPlatformCoreBundle">
+    <directory>tests/EzPlatformCoreBundle/bundle</directory>
+  </testsuite>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<phpunit
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  colors="true"
+>
+  <php>
+    <ini name="error_reporting" value="-1" />
+  </php>
+</phpunit>

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Configuration.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformCoreBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder(EzPlatformCoreExtension::EXTENSION_ALIAS);
+
+        $rootNode = $treeBuilder->getRootNode();
+
+        return $treeBuilder;
+    }
+}

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Configuration.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Configuration.php
@@ -20,9 +20,12 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder(EzPlatformCoreExtension::EXTENSION_ALIAS);
+        $treeBuilder = new TreeBuilder();
 
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root(EzPlatformCoreExtension::EXTENSION_ALIAS);
+
+        // @todo define actual configuration (move from EzPublishCoreBundle)
+        $rootNode->variablePrototype();
 
         return $treeBuilder;
     }

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformCoreBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class EzPlatformCoreExtension extends Extension
+{
+    public const EXTENSION_ALIAS = 'ezplatform';
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = $this->getConfiguration($configs, $container);
+        $config = $this->processConfiguration($configuration, $configs);
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
+    {
+        return new Configuration();
+    }
+
+    public function getAlias(): string
+    {
+        return self::EXTENSION_ALIAS;
+    }
+}

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -11,24 +11,40 @@ namespace EzSystems\EzPlatformCoreBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
-final class EzPlatformCoreExtension extends Extension
+final class EzPlatformCoreExtension extends Extension implements PrependExtensionInterface
 {
     public const EXTENSION_ALIAS = 'ezplatform';
 
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $configuration = $this->getConfiguration($configs, $container);
-        $config = $this->processConfiguration($configuration, $configs);
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
-    {
+    public function getConfiguration(
+        array $config,
+        ContainerBuilder $container
+    ): ConfigurationInterface {
         return new Configuration();
     }
 
     public function getAlias(): string
     {
         return self::EXTENSION_ALIAS;
+    }
+
+    /**
+     * Prepend "ezplatform" configuration to "ezpublish" configuration.
+     *
+     * @todo remove once we replace EzPublishCoreBundle with EzPlatformCoreBundle
+     */
+    public function prepend(ContainerBuilder $container): void
+    {
+        // inject "ezplatform" extension settings into "ezpublish" extension
+        // configuration here is zero-based array of configurations from multiple sources
+        // to be merged by "ezpublish" extension
+        foreach ($container->getExtensionConfig('ezplatform') as $eZPlatformConfig) {
+            $container->prependExtensionConfig('ezpublish', $eZPlatformConfig);
+        }
     }
 }

--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformCoreBundle;
+
+use EzSystems\EzPlatformCoreBundle\DependencyInjection\EzPlatformCoreExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class EzPlatformCoreBundle extends Bundle
+{
+    public function getContainerExtension(): ExtensionInterface
+    {
+        return new EzPlatformCoreExtension();
+    }
+}

--- a/tests/EzPlatformCoreBundle/bundle/EzPlatformCoreBundleTest.php
+++ b/tests/EzPlatformCoreBundle/bundle/EzPlatformCoreBundleTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformCoreBundle;
+
+use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use PHPUnit\Framework\TestCase;
+
+final class EzPlatformCoreBundleTest extends TestCase
+{
+    public function testInstantiateBundle(): void
+    {
+        $bundle = new EzPlatformCoreBundle();
+        self::assertEquals('EzPlatformCoreBundle', $bundle->getName());
+        self::assertEquals('ezplatform', $bundle->getContainerExtension()->getAlias());
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30636](https://jira.ez.no/browse/EZP-30636)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `1.0` for eZ Platform `v2.5.x` LTS and `3.0@beta2`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR provides forward compatibility with eZ Platform 3.0 by means of eZ Platform Core Bundle and its Extension, so the Developers and Maintainers are able to prefix their eZ Platform configuration with
``` yaml
ezplatform:
```
instead of
``` yaml
ezpublish:
```

Current implementation simply prepends `ezplatform` configuration to `ezpublish` extension. This by no means is a complete solution. It's rather a workaround to simplify migration.

For eZ Platform 3.0 we plan to provide fully functional `EzPlatformCoreBundle` which registers `ezplatform` extension and replaces `EzPublishCoreBundle` and `ezpublish` extension.

I still believe this is a good way to go, even if it is a workaround. I took into the account suggestions from the internal Sprint Demo and targeted it for eZ Platform 2.5.x LTS so that PR provides more significant value.

### Open question

- [x] ~Should we drop "Core" from the Bundle and Extension name? So it's just `EzPlatformBundle` and `EzPlatformExtension`?~ // Internal Sync: No.

### Doc

To use `ezplatform` instead of `ezpublish` in their 2.5.x `ezplatform.yml` configuration files, the Developers must enable the `EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle` in their Kernel.

#### v2.5
`app/AppKernel.php`:
``` php
        $bundles = [
            // ...
            new EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle(),
            // ...
        ];
```

#### v3.0
`config/bundles.php`:
``` php
return [
    // ...
    EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle::class => ['all' => true],
    // ...
];
```

### QA

- [ ] Test configuration of `ezplatform` extension (replacing `ezpublish` with `ezplatform` in `ezplatform.yml` (you could use the [alongosz:ezp-30636-ezplatform-extension](https://github.com/ezsystems/ezplatform/compare/2.5...alongosz:ezp-30636-ezplatform-extension) branch),
- [ ] Perform sanity checks for the current `ezpublish` configuration.

**TODO**
- [x] Rebase after merging #10
- [x] Create Bundle.
- [x] Create Extension.
- [x] Prepend `ezpublish` extension with config from `ezplatform` extension.
- [x] Double check if everything is working as expected.