### PR TITLE
Back-ported #10: Code Style checking job with initial Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: php
+php: '7.3'
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
+# test only master, stable branches and pull requests
+branches:
+    only:
+        - master
+        - /^\d.\d+$/
+
+before_install:
+    # Disable memory_limit for composer
+    - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    # Disable XDebug for all jobs as we don't generate test coverge on travis
+    - phpenv config-rm xdebug.ini
+    # make sure we use UTF-8 encoding
+    - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+install:
+    - travis_retry composer install --no-progress --no-interaction --no-suggest --prefer-dist
+
+matrix:
+    include:
+        - name: 'Code Style check'
+          php: '7.3'
+          script:
+              - composer fix-cs
+
+notifications:
+    slack:
+        rooms:
+            - secure: YzZCmiziVQLVJBgxGmsN+QmXoarDMCJPBJ/OqM8VnlD7oN36K9owYSnrOUVGCQKPjuK8SnFiMTzcJBJ/AHl0MX4TC2Bro54hHXFruJ5NQzGY7hdCAcXUzMgeXUg7pjwAS++3kTKRhab27elLjxwOT9Io/Csem4JrZbNvCS7+0f4dRoAqDRYQXf/BJ/tW5qM4c7g9jxbd80pjirqVO47BmPdRqSFK/Dm3tc7HAgsIgJpzie9tfe8H/2hYlsA/RdV0zkYtlZ78Kx2nfDh1Ap/WQJBveQBb4qhWmjpbuJptBCY5Ho/+v8+200vZf+6HiBV+oj0L4s8LIRZJxaTqGnPT8s6FUwuaiGwnBKLTQs8QWIRklfVX6Ih/+yNHT5JvmEW227ZAgfHom51nGZayxwpptSUxy3XXTHKXtX8I48qQHVKU8oXx7kG17KMggJIzZtljdts1n3WWf5eqvtUNpV5A5tjGe6ehuQTg4eBx6GzsiULCFo7rOr1Hg/lmAefrJO/+/C21OqTb0DsFtDG9gMuaQNnFidGe2nKu5EbjY24Ivgi0FYbSprjgNVHmLVGHm5zfzlxMM7D2tBvN3iZYiFgrWSP+6rAZZNUcgK6AN0kZczd9AIQs0lHOMPb1o5FHH0lM/uDb3SSyxF+m98SN5nvy1tOdr2pox2JVL2hK1m5vKY8=
+        on_success: change
+        on_failure: always
+        on_pull_requests: false
+
+# reduce depth (history) of git checkout
+git:
+    depth: 30

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/symfony": "^3.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.7.1",
+        "friendsofphp/php-cs-fixer": "^2.15",
         "phpunit/phpunit": "^6.4"
     },
     "scripts": {


### PR DESCRIPTION
Seems we might need Travis setup in the future for 1.0 (for eZ Platform 2.5 LTS). This PR back-ports #10.

**TODO**
- [x] Wait for Travis to pass before merging.