### PR TITLE
EZP-31079: Bundle provides a way to inject contextual Twig variables

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,38 +1,9 @@
 <?php
 
-$header = <<<'EOF'
-@copyright Copyright (C) eZ Systems AS. All rights reserved.
-@license For full copyright and license information view LICENSE file distributed with this source code.
-EOF;
-
-return PhpCsFixer\Config::create()
-    ->setRules([
-        '@Symfony' => true,
-        '@Symfony:risky' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'array_syntax' => ['syntax' => 'short'],
-        'simplified_null_return' => false,
-        'phpdoc_align' => false,
-        'phpdoc_to_comment' => false,
-        'cast_spaces' => false,
-        'blank_line_after_opening_tag' => false,
-        'single_blank_line_before_namespace' => false,
-        'space_after_semicolon' => false,
-        'header_comment' => [
-            'commentType' => 'PHPDoc',
-            'header' => $header,
-            'location' => 'after_open',
-            'separate' => 'top',
-        ],
-        'yoda_style' => false,
-        'no_break_comment' => false,
-        'self_accessor' => false,
-        'declare_strict_types' => true,
-    ])
-    ->setRiskyAllowed(true)
+return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
     ->setFinder(
         PhpCsFixer\Finder::create()
-            ->in([__DIR__ . '/src', __DIR__ . '/tests'])
+            ->in(__DIR__ . '/src')
             ->files()->name('*.php')
     )
 ;

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
-        "phpunit/phpunit": "^8.3.5"
+        "phpunit/phpunit": "^8.3.5",
+        "ezsystems/ezplatform-code-style": "^0.1.0"
     },
     "scripts": {
         "test": "phpunit -v -c phpunit.xml",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     "autoload": {
         "psr-4": {
             "EzSystems\\EzPlatformCoreBundle\\": "src/EzPlatformCoreBundle/bundle/",
-            "EzSystems\\EzPlatformEncoreBundle\\": "src/EzPlatformEncoreBundle/bundle/"
+            "EzSystems\\EzPlatformEncoreBundle\\": "src/EzPlatformEncoreBundle/bundle/",
+            "EzSystems\\EzPlatformTemplating\\": "src/EzPlatformTemplatingBundle/lib/",
+            "EzSystems\\EzPlatformTemplatingBundle\\": "src/EzPlatformTemplatingBundle/bundle/"
         }
     },
     "autoload-dev": {
@@ -20,13 +22,17 @@
             "EzSystems\\Tests\\EzPlatformCoreBundle\\": "tests/EzPlatformCoreBundle/bundle/"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "^7.3",
         "symfony/config": "^4.3",
         "symfony/dependency-injection": "^4.3",
         "symfony/filesystem": "^4.3",
         "symfony/finder": "^4.3",
-        "symfony/http-kernel": "^4.3"
+        "symfony/http-kernel": "^4.3",
+        "symfony/twig-bundle": "^4.3",
+        "ezsystems/ezpublish-kernel": "^8.0@dev"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,13 @@
   <php>
     <ini name="error_reporting" value="-1" />
   </php>
-  <testsuite name="EzPlatformCoreBundle">
-    <directory>tests/EzPlatformCoreBundle/bundle</directory>
-  </testsuite>
+  <testsuites>
+    <testsuite name="EzPlatformCoreBundle">
+      <directory>tests/EzPlatformCoreBundle/bundle</directory>
+    </testsuite>
+    <testsuite name="EzPlatformTemplatingBundle">
+      <directory>tests/EzPlatformTemplatingBundle/bundle</directory>
+      <directory>tests/EzPlatformTemplatingBundle/lib</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/EzPlatformTemplatingBundle/bundle/DependencyInjection/Configuration/Parser/TwigVariablesParser.php
+++ b/src/EzPlatformTemplatingBundle/bundle/DependencyInjection/Configuration/Parser/TwigVariablesParser.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplatingBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class TwigVariablesParser extends AbstractParser
+{
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('twig_variables')
+                ->info('Contextual Twig variables.')
+                ->useAttributeAsKey('name')
+                ->normalizeKeys(false)
+                ->example([
+                    'some' => 'variable',
+                    'nested' => [
+                        'some' => 'variable',
+                        'other' => 123,
+                    ],
+                ])
+                ->prototype('variable')->end()
+            ->end();
+    }
+
+    public function mapConfig(
+        array &$scopeSettings,
+        $currentScope,
+        ContextualizerInterface $contextualizer
+    ) {
+        if (!empty($scopeSettings['twig_variables'])) {
+            $settings = $scopeSettings['twig_variables'];
+
+            $contextualizer->setContextualParameter(
+                'twig_variables',
+                $currentScope,
+                $settings
+            );
+        }
+    }
+}

--- a/src/EzPlatformTemplatingBundle/bundle/DependencyInjection/EzPlatformTemplatingExtension.php
+++ b/src/EzPlatformTemplatingBundle/bundle/DependencyInjection/EzPlatformTemplatingExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplatingBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class EzPlatformTemplatingExtension extends Extension
+{
+    public function load(
+        array $configs,
+        ContainerBuilder $container
+    ) {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config')
+        );
+
+        $loader->load('services.yaml');
+    }
+}

--- a/src/EzPlatformTemplatingBundle/bundle/EzPlatformTemplatingBundle.php
+++ b/src/EzPlatformTemplatingBundle/bundle/EzPlatformTemplatingBundle.php
@@ -19,7 +19,7 @@ class EzPlatformTemplatingBundle extends Bundle
         parent::build($container);
 
         /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $kernelExtension */
-        $kernelExtension = $container->getExtension('ezpublish');
+        $kernelExtension = $container->getExtension('ezplatform');
 
         $configParsers = $this->getConfigParsers();
         array_walk($configParsers, [$kernelExtension, 'addConfigParser']);

--- a/src/EzPlatformTemplatingBundle/bundle/EzPlatformTemplatingBundle.php
+++ b/src/EzPlatformTemplatingBundle/bundle/EzPlatformTemplatingBundle.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplatingBundle;
+
+use EzSystems\EzPlatformTemplatingBundle\DependencyInjection\Configuration\Parser\TwigVariablesParser;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class EzPlatformTemplatingBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $kernelExtension */
+        $kernelExtension = $container->getExtension('ezpublish');
+
+        $configParsers = $this->getConfigParsers();
+        array_walk($configParsers, [$kernelExtension, 'addConfigParser']);
+    }
+
+    private function getConfigParsers(): array
+    {
+        return [
+            new TwigVariablesParser(),
+        ];
+    }
+}

--- a/src/EzPlatformTemplatingBundle/bundle/Resources/config/services.yaml
+++ b/src/EzPlatformTemplatingBundle/bundle/Resources/config/services.yaml
@@ -1,0 +1,19 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+        public: false
+
+    EzSystems\EzPlatformTemplatingBundle\Templating\Twig\ContextAwareTwigVariablesExtension:
+        arguments:
+            $configResolver: "@ezpublish.config.resolver"
+        tags:
+            - { name: twig.extension }
+
+    EzSystems\EzPlatformTemplating\Core\EventListener\ContentViewSubscriber: ~
+
+    EzSystems\EzPlatformTemplating\Core\View\ParameterProviderRegistry:
+        arguments:
+            $twigVariableProviders: !tagged ezplatform.view.parameter_provider
+
+    EzSystems\EzPlatformTemplating\SPI\View\ParameterProviderRegistry: '@EzSystems\EzPlatformTemplating\Core\View\ParameterProviderRegistry'

--- a/src/EzPlatformTemplatingBundle/bundle/Templating/Twig/ContextAwareTwigVariablesExtension.php
+++ b/src/EzPlatformTemplatingBundle/bundle/Templating/Twig/ContextAwareTwigVariablesExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplatingBundle\Templating\Twig;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+class ContextAwareTwigVariablesExtension extends AbstractExtension implements GlobalsInterface
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->configResolver = $configResolver;
+    }
+
+    public function getGlobals(): array
+    {
+        return $this->configResolver->hasParameter('twig_variables')
+            ? $this->configResolver->getParameter('twig_variables')
+            : [];
+    }
+}

--- a/src/EzPlatformTemplatingBundle/lib/Core/EventListener/ContentViewSubscriber.php
+++ b/src/EzPlatformTemplatingBundle/lib/Core/EventListener/ContentViewSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplating\Core\EventListener;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use EzSystems\EzPlatformTemplating\SPI\View\VariableProviderRegistry;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+final class ContentViewSubscriber implements EventSubscriberInterface
+{
+    public const TWIG_VARIABLES_KEY = 'twig_variables';
+
+    private const PARAMETER_EXPRESSION_KEY = '_expression';
+    private const PARAMETER_PROVIDER_KEY = '_provider';
+
+    /** @var \EzSystems\EzPlatformTemplating\SPI\View\VariableProviderRegistry */
+    private $parameterProviderRegistry;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /** @var \Symfony\Component\ExpressionLanguage\ExpressionLanguage */
+    private $expressionLanguage;
+
+    public function __construct(
+        VariableProviderRegistry $parameterProviderRegistry,
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->parameterProviderRegistry = $parameterProviderRegistry;
+        $this->configResolver = $configResolver;
+        $this->expressionLanguage = new ExpressionLanguage();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            MVCEvents::PRE_CONTENT_VIEW => 'onPreContentView',
+        ];
+    }
+
+    public function onPreContentView(PreContentViewEvent $event): void
+    {
+        $view = $event->getContentView();
+        $twigVariables = $view->getConfigHash()[self::TWIG_VARIABLES_KEY] ?? [];
+
+        foreach ($twigVariables as $name => &$twigVariable) {
+            if ($this->isExpressionParameter($twigVariable)) {
+                $twigVariable = $this->expressionLanguage->evaluate($twigVariable[self::PARAMETER_EXPRESSION_KEY], [
+                    'view' => $view,
+                    'parameters' => $view->getParameters(),
+                    'content' => $view->getContent(),
+                    'location' => $view->getLocation(),
+                    'config' => $this->configResolver,
+                ]);
+            } elseif ($this->isProviderParameter($twigVariable)) {
+                $provider = $this->parameterProviderRegistry->getTwigVariableProvider($twigVariable[self::PARAMETER_PROVIDER_KEY]);
+                $twigVariable = $provider->getTwigVariables($view, $twigVariable ?? []);
+            }
+        }
+
+        $view->setParameters(array_replace($view->getParameters() ?? [], $twigVariables));
+    }
+
+    private function isExpressionParameter($twigVariable): bool
+    {
+        return !empty($twigVariable[self::PARAMETER_EXPRESSION_KEY])
+            && \is_string($twigVariable[self::PARAMETER_EXPRESSION_KEY]);
+    }
+
+    private function isProviderParameter($twigVariable): bool
+    {
+        return !empty($twigVariable[self::PARAMETER_PROVIDER_KEY])
+            && $this->parameterProviderRegistry->hasTwigVariableProvider($twigVariable[self::PARAMETER_PROVIDER_KEY]);
+    }
+}

--- a/src/EzPlatformTemplatingBundle/lib/Core/View/VariableProviderRegistry.php
+++ b/src/EzPlatformTemplatingBundle/lib/Core/View/VariableProviderRegistry.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplating\Core\View;
+
+use EzSystems\EzPlatformTemplating\SPI\View\VariableProvider;
+use EzSystems\EzPlatformTemplating\SPI\View\VariableProviderRegistry as ParameterProviderRegistryInterface;
+use Traversable;
+
+final class VariableProviderRegistry implements ParameterProviderRegistryInterface
+{
+    /** @var \EzSystems\EzPlatformTemplating\SPI\View\VariableProvider[] */
+    private $twigVariableProviders;
+
+    public function __construct(Traversable $twigVariableProviders)
+    {
+        foreach ($twigVariableProviders as $twigVariableProvider) {
+            $this->setTwigVariableProvider($twigVariableProvider);
+        }
+    }
+
+    public function setTwigVariableProvider(VariableProvider $twigVariableProvider): void
+    {
+        $this->twigVariableProviders[$twigVariableProvider->getIdentifier()] = $twigVariableProvider;
+    }
+
+    public function getTwigVariableProvider(string $identifier): ?VariableProvider
+    {
+        return $this->twigVariableProviders[$identifier] ?? null;
+    }
+
+    public function hasTwigVariableProvider(string $identifier): bool
+    {
+        return isset($this->twigVariableProviders[$identifier]);
+    }
+}

--- a/src/EzPlatformTemplatingBundle/lib/SPI/View/VariableProvider.php
+++ b/src/EzPlatformTemplatingBundle/lib/SPI/View/VariableProvider.php
@@ -14,5 +14,5 @@ interface VariableProvider
 {
     public function getIdentifier(): string;
 
-    public function getTwigVariables(View $view, array $options = []): array;
+    public function getTwigVariables(View $view, array $options = []): object;
 }

--- a/src/EzPlatformTemplatingBundle/lib/SPI/View/VariableProvider.php
+++ b/src/EzPlatformTemplatingBundle/lib/SPI/View/VariableProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplating\SPI\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+interface VariableProvider
+{
+    public function getIdentifier(): string;
+
+    public function getTwigVariables(View $view, array $options = []): array;
+}

--- a/src/EzPlatformTemplatingBundle/lib/SPI/View/VariableProviderRegistry.php
+++ b/src/EzPlatformTemplatingBundle/lib/SPI/View/VariableProviderRegistry.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformTemplating\SPI\View;
+
+interface VariableProviderRegistry
+{
+    public function setTwigVariableProvider(VariableProvider $twigVariableProvider): void;
+
+    public function getTwigVariableProvider(string $identifier): ?VariableProvider;
+
+    public function hasTwigVariableProvider(string $identifier): bool;
+}

--- a/tests/EzPlatformTemplatingBundle/bundle/EzPlatformTemplatingBundleTest.php
+++ b/tests/EzPlatformTemplatingBundle/bundle/EzPlatformTemplatingBundleTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformTemplatingBundle;
+
+use EzSystems\EzPlatformTemplatingBundle\EzPlatformTemplatingBundle;
+use PHPUnit\Framework\TestCase;
+
+final class EzPlatformTemplatingBundleTest extends TestCase
+{
+    public function testInstantiateBundle(): void
+    {
+        $bundle = new EzPlatformTemplatingBundle();
+        self::assertEquals('EzPlatformTemplatingBundle', $bundle->getName());
+    }
+}

--- a/tests/EzPlatformTemplatingBundle/bundle/Templating/Twig/ContextAwareTwigVariablesExtensionTest.php
+++ b/tests/EzPlatformTemplatingBundle/bundle/Templating/Twig/ContextAwareTwigVariablesExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformTemplatingBundle\Templating\Twig;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformTemplatingBundle\Templating\Twig\ContextAwareTwigVariablesExtension;
+use PHPUnit\Framework\TestCase;
+
+class ContextAwareTwigVariablesExtensionTest extends TestCase
+{
+    public function testNoVariables(): void
+    {
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+
+        $extension = new ContextAwareTwigVariablesExtension($configResolverMock);
+
+        $this->assertSame($extension->getGlobals(), []);
+    }
+
+    public function testVariables(): void
+    {
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+
+        $configResolverMock->method('hasParameter')
+            ->with('twig_variables')
+            ->willReturn(true);
+
+        $configResolverMock->method('getParameter')
+            ->with('twig_variables')
+            ->willReturn([
+                'some' => 'global',
+                'variable' => 'value',
+            ]);
+
+        $extension = new ContextAwareTwigVariablesExtension($configResolverMock);
+
+        $this->assertSame($extension->getGlobals(), [
+            'some' => 'global',
+            'variable' => 'value',
+        ]);
+    }
+}

--- a/tests/EzPlatformTemplatingBundle/lib/BaseTemplatingTest.php
+++ b/tests/EzPlatformTemplatingBundle/lib/BaseTemplatingTest.php
@@ -52,9 +52,9 @@ abstract class BaseTemplatingTest extends TestCase
                 return $this->identifier;
             }
 
-            public function getTwigVariables(View $view, array $options = []): array
+            public function getTwigVariables(View $view, array $options = []): object
             {
-                return [
+                return (object)[
                     $this->identifier . '_parameter' => $this->identifier . '_value',
                 ];
             }

--- a/tests/EzPlatformTemplatingBundle/lib/BaseTemplatingTest.php
+++ b/tests/EzPlatformTemplatingBundle/lib/BaseTemplatingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformTemplating;
+
+use ArrayIterator;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use EzSystems\EzPlatformTemplating\Core\View\VariableProviderRegistry;
+use EzSystems\EzPlatformTemplating\SPI\View\VariableProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTemplatingTest extends TestCase
+{
+    protected function getContentViewMock(): MockObject
+    {
+        $view = $this->createMock(ContentView::class);
+
+        $view->method('getContent')->willReturn(new Content());
+        $view->method('getLocation')->willReturn(new Location());
+
+        return $view;
+    }
+
+    protected function getRegistry(array $providers): VariableProviderRegistry
+    {
+        return new VariableProviderRegistry(
+            new ArrayIterator($providers)
+        );
+    }
+
+    protected function getProvider(string $identifier): VariableProvider
+    {
+        return new class($identifier) implements VariableProvider {
+            private $identifier;
+
+            public function __construct(string $identifier)
+            {
+                $this->identifier = $identifier;
+            }
+
+            public function getIdentifier(): string
+            {
+                return $this->identifier;
+            }
+
+            public function getTwigVariables(View $view, array $options = []): array
+            {
+                return [
+                    $this->identifier . '_parameter' => $this->identifier . '_value',
+                ];
+            }
+        };
+    }
+}

--- a/tests/EzPlatformTemplatingBundle/lib/EventListener/ContentViewSubscriberTest.php
+++ b/tests/EzPlatformTemplatingBundle/lib/EventListener/ContentViewSubscriberTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformTemplating\EventListener;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\EzPlatformTemplating\Core\EventListener\ContentViewSubscriber;
+use EzSystems\EzPlatformTemplating\SPI\View\VariableProvider;
+use EzSystems\Tests\EzPlatformTemplating\BaseTemplatingTest;
+
+final class ContentViewSubscriberTest extends BaseTemplatingTest
+{
+    private function getContentViewMockSubscriber(): ContentViewSubscriber
+    {
+        return new ContentViewSubscriber(
+            $this->getRegistry([
+                $this->getProvider('test_provider'),
+            ]),
+            $this->createMock(ConfigResolverInterface::class)
+        );
+    }
+
+    public function testWithoutVariables(): void
+    {
+        $view = $this->getContentViewMock();
+        $event = new PreContentViewEvent($view);
+
+        $view
+            ->expects($this->once())
+            ->method('setParameters')
+            ->with([]);
+
+        $subscriber = $this->getContentViewMockSubscriber();
+        $subscriber->onPreContentView($event);
+    }
+
+    public function testWithScalarVariables(): void
+    {
+        $view = $this->getContentViewMock();
+        $event = new PreContentViewEvent($view);
+
+        $view->method('getConfigHash')
+            ->willReturn([
+                ContentViewSubscriber::TWIG_VARIABLES_KEY => [
+                    'param_1' => 'scalar_1',
+                    'param_2' => 2,
+                    'param_3' => 3,
+                ],
+            ]);
+
+        $view
+            ->expects($this->once())
+            ->method('setParameters')
+            ->with([
+                'param_1' => 'scalar_1',
+                'param_2' => 2,
+                'param_3' => 3,
+            ]);
+
+        $subscriber = $this->getContentViewMockSubscriber();
+        $subscriber->onPreContentView($event);
+    }
+
+    public function testOverwriteVariables(): void
+    {
+        $view = $this->getContentViewMock();
+        $event = new PreContentViewEvent($view);
+
+        $view->method('getConfigHash')
+            ->willReturn([
+                ContentViewSubscriber::TWIG_VARIABLES_KEY => [
+                    'param_1' => 'scalar_1',
+                ],
+            ]);
+
+        $view->method('getParameters')
+            ->willReturn([
+                'param_1' => 'existing_value',
+                'param_2' => 'also_existing_value',
+            ]);
+
+        $view
+            ->expects($this->once())
+            ->method('setParameters')
+            ->with([
+                'param_1' => 'scalar_1',
+                'param_2' => 'also_existing_value',
+            ]);
+
+        $subscriber = $this->getContentViewMockSubscriber();
+        $subscriber->onPreContentView($event);
+    }
+
+    public function testWithExpressionParam(): void
+    {
+        $view = $this->getContentViewMock();
+        $event = new PreContentViewEvent($view);
+
+        $randomNumber = rand(100, 200);
+
+        $view->method('getParameters')
+            ->willReturn([
+                'random_number' => $randomNumber,
+            ]);
+
+        $view->method('getConfigHash')
+            ->willReturn([
+                ContentViewSubscriber::TWIG_VARIABLES_KEY => [
+                    'plus_42' => [
+                        '_expression' => 'parameters["random_number"] + 42',
+                    ],
+                ],
+            ]);
+
+        $view
+            ->expects($this->once())
+            ->method('setParameters')
+            ->with([
+                'random_number' => $randomNumber,
+                'plus_42' => $randomNumber + 42,
+            ]);
+
+        $subscriber = $this->getContentViewMockSubscriber();
+        $subscriber->onPreContentView($event);
+    }
+
+    public function testWithProviderAndOptionsParam(): void
+    {
+        $view = $this->getContentViewMock();
+        $event = new PreContentViewEvent($view);
+
+        $view->method('getParameters')
+            ->willReturn([
+                'meaning_of_life' => 42,
+            ]);
+
+        $view->method('getConfigHash')
+            ->willReturn([
+                ContentViewSubscriber::TWIG_VARIABLES_KEY => [
+                    'provider_param' => [
+                        '_provider' => 'provider_with_options',
+                        'some_number' => 123,
+                    ],
+                ],
+            ]);
+
+        $view
+            ->expects($this->once())
+            ->method('setParameters')
+            ->with([
+                'meaning_of_life' => 42,
+                'provider_param' => [
+                    'result' => 165,
+                ],
+            ]);
+
+        $subscriber = new ContentViewSubscriber(
+            $this->getRegistry([
+                new class() implements VariableProvider {
+                    public function getIdentifier(): string
+                    {
+                        return 'provider_with_options';
+                    }
+
+                    public function getTwigVariables(
+                        View $view,
+                        array $options = []
+                    ): array {
+                        return [
+                            'result' => $view->getParameters()['meaning_of_life'] + $options['some_number'],
+                        ];
+                    }
+                },
+            ]),
+            $this->createMock(ConfigResolverInterface::class)
+        );
+        $subscriber->onPreContentView($event);
+    }
+}

--- a/tests/EzPlatformTemplatingBundle/lib/View/VariableProviderRegistryTest.php
+++ b/tests/EzPlatformTemplatingBundle/lib/View/VariableProviderRegistryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformTemplating\View;
+
+use EzSystems\Tests\EzPlatformTemplating\BaseTemplatingTest;
+
+final class VariableProviderRegistryTest extends BaseTemplatingTest
+{
+    public function testParameterProviderGetter(): void
+    {
+        $registry = $this->getRegistry([
+            $this->getProvider('provider_a'),
+            $this->getProvider('provider_b'),
+        ]);
+
+        $providerA = $registry->getTwigVariableProvider('provider_a');
+        $providerB = $registry->getTwigVariableProvider('provider_b');
+        $providerC = $registry->getTwigVariableProvider('provider_c');
+
+        $this->assertEquals($providerA->getIdentifier(), 'provider_a');
+        $this->assertEquals($providerB->getIdentifier(), 'provider_b');
+        $this->assertNull($providerC);
+    }
+
+    public function testParameterProviderSetter(): void
+    {
+        $registry = $this->getRegistry([
+            $this->getProvider('provider_a'),
+            $this->getProvider('provider_b'),
+        ]);
+
+        $providerC = $registry->getTwigVariableProvider('provider_c');
+
+        $this->assertNull($providerC);
+
+        $registry->setTwigVariableProvider($this->getProvider('provider_c'));
+
+        $providerC = $registry->getTwigVariableProvider('provider_c');
+        $this->assertEquals($providerC->getIdentifier(), 'provider_c');
+    }
+
+    public function testParameterProviderChecker(): void
+    {
+        $registry = $this->getRegistry([
+            $this->getProvider('provider_a'),
+            $this->getProvider('provider_b'),
+        ]);
+
+        $this->assertTrue($registry->hasTwigVariableProvider('provider_a'));
+        $this->assertTrue($registry->hasTwigVariableProvider('provider_b'));
+        $this->assertFalse($registry->hasTwigVariableProvider('provider_c'));
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31079](https://jira.ez.no/browse/EZP-31079)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

#### SiteAccess contextual variables:

```yaml
ezplatform:
    system:
        my_siteaccess:
            twig_variables:
                some: "variable"
                nested:
                    other: "other variable"
                    number: 123
                cache_ttl: "%httpcache_default_ttl%"
```

#### ContentView contextual variables: 

```yaml
system:
    my_siteaccess:
        content_view:
            full:
                default:
                    template: '@ezdesign/my_content/my_location_view.html.twig'
                    params:
                        some: "variable"
                        nested:
                            other: "other variable"
                            number: 123
                            deeper:
                                nested_expression: "@=content.contentTypeIdentifier"
                        provided_variable: "@=provider("my_variable_provider").my_variable
                    match: true
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
