### PR TITLE
EZP-31007: Introduced eZ Platform version reference

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -14,6 +14,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class EzPlatformCoreBundle extends Bundle
 {
+    /**
+     * eZ Platform Version.
+     */
+    public const VERSION = '3.0.0';
+
     public function getContainerExtension(): ExtensionInterface
     {
         return new EzPlatformCoreExtension();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Required by** | ezsystems/ez-support-tools#47
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `2.0` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no (internal feature)

With the change of `ezplatform-kernel` package name (ezsystems/ezplatform#510), Product version detection stopped working.
My suggestion is to use a `const` as this is done for a lot of other software.

`const` needs to be updated after each release, but not necessarily immediately, as long as its before the next release.

Why not do it in `ezplatform-kernel`? Well, the architecture around that package is being redesigned, moreover I want to avoid referencing something from `eZ\Publish` namespace if not needed.

Current state, with the const value:
```php
    /**
     * eZ Platform Version.
     */
    public const VERSION = '3.0.0';
```
is as follows:
![image](https://user-images.githubusercontent.com/7099219/77154982-16041f00-6a9d-11ea-806c-2e723b4622f2.png).

**TODO**:
- [x] Add the `VERSION` const.
- [x] `ez-support-tools` PR (ezsystems/ez-support-tools#47)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
