### PR TITLE
Bumped eZ Platform version to 3.0.4

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -17,7 +17,7 @@ final class EzPlatformCoreBundle extends Bundle
     /**
      * eZ Platform Version.
      */
-    public const VERSION = '3.0.2';
+    public const VERSION = '3.0.4';
 
     public function getContainerExtension(): ExtensionInterface
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Target eZ Platform version** | 3.0.4

Bumped eZ Platform version constant to prepare for release of v3.0.4.
I'm sorry I forgot to do it before 3.0.3 :(