### PR TITLE
Bump version to 3.0.5

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -17,7 +17,7 @@ final class EzPlatformCoreBundle extends Bundle
     /**
      * eZ Platform Version.
      */
-    public const VERSION = '3.0.4';
+    public const VERSION = '3.0.5';
 
     public function getContainerExtension(): ExtensionInterface
     {


### PR DESCRIPTION
Bumped eZ Platform version to `v3.0.5`.