### PR TITLE
EZP-31986: CompileAssetsCommand does not throw an exception when failing

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -78,6 +78,15 @@ class CompileAssetsCommand extends ContainerAwareCommand
             );
         });
 
+        if (!$process->isSuccessful()) {
+            throw new RuntimeException(sprintf(
+                "An error occurred when executing the \"%s\" command:\n\n%s\n",
+                self::COMMAND_NAME,
+                $process->getOutput(),
+                $process->getErrorOutput())
+            );
+        }
+
         $output->writeln(
             $debugFormatter->stop(
                 spl_object_hash($process),

--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -80,8 +80,8 @@ class CompileAssetsCommand extends ContainerAwareCommand
 
         if (!$process->isSuccessful()) {
             throw new RuntimeException(sprintf(
-                "An error occurred when executing the \"%s\" command:\n\n%s\n",
-                self::COMMAND_NAME,
+                "An error occurred when executing the \"%s\" command:\n\n%s\n\n%s",
+                $yarnEncoreCommand,
                 $process->getOutput(),
                 $process->getErrorOutput())
             );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31986](https://jira.ez.no/browse/EZP-31986)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0`, `2.1`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

JIRA excerpt:
>Currently, `CompileAssetsCommand` throws no exception in case of e.g. syntax error. That results in a successfully finished build. Due to that, the site might be missing a `manifest.json` file that causes 500 error.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
