### PR TITLE
EZP-31986: Added missing RuntimeException import to CompileAssetsCommand

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformEncoreBundle\Command;
 
 use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31986](https://jira.ez.no/browse/EZP-31986)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for https://github.com/ezsystems/ezplatform-core/pull/19 . Currently ezplatform:encore:compile throws 

```
In CompileAssetsCommand.php line 82:
!!                                                                                 
!!    Attempted to load class "RuntimeException" from namespace "EzSystems\EzPlat  
!!    formEncoreBundle\Command".                                                   
!!    Did you forget a "use" statement for e.g. "Webimpress\SafeWriter\Exception\  
!!    RuntimeException", "Symfony\Component\Yaml\Exception\RuntimeException", "Sy  
!!    mfony\Component\Validator\Exception\RuntimeException", "Symfony\Component\T  
!!    ranslation\Exception\RuntimeException", "Symfony\Component\String\Exception  
!!    \RuntimeException", "Symfony\Component\Serializer\Exception\RuntimeExceptio  
!!    n", "Symfony\Component\Security\Core\Exception\RuntimeException", "Symfony\  
!!    Component\PropertyAccess\Exception\RuntimeException", "Symfony\Component\Pr  
!!    ocess\Exception\RuntimeException", "Symfony\Component\Mime\Exception\Runtim  
!!    eException", "Symfony\Component\Intl\Exception\RuntimeException", "Symfony\  
!!    Component\Form\Exception\RuntimeException", "Symfony\Component\DependencyIn  
!!    jection\Exception\RuntimeException", "Symfony\Component\Console\Exception\R  
!!    untimeException", "SensioLabs\Security\Exception\RuntimeException", "Pagerf  
!!    anta\Exception\RuntimeException", "Laminas\EventManager\Exception\RuntimeEx  
!!    ception", "Laminas\Code\Exception\RuntimeException", "Laminas\Code\Generato  
!!    r\Exception\RuntimeException", "Laminas\Code\Reflection\Exception\RuntimeEx  
!!    ception", "JMS\TranslationBundle\Exception\RuntimeException", "JMS\Serializ  
!!    er\Exception\RuntimeException" or "Imagine\Exception\RuntimeException"?      
!!                                                                                 
```
when subprocess execution failed.  Correct output is 

```
 An error occurred when executing the "yarn encore dev" command:              
!!                                                                                 
!!    yarn run v1.3.2                                                              
!!    $ /home/awojs/eZ/ezplatform-sf-recipies/node_modules/.bin/encore dev         
!!    Running webpack ...                                                          
!!                                                                                 
!!     ERROR  Failed to compile with 1 errors2:28:20 PM                            
!!                                                                                 
!!     ....
!!               
!!    (node:14554) [DEP0005] DeprecationWarning: Buffer() is deprecated due to se  
!!    curity and usability issues. Please use the Buffer.alloc(), Buffer.allocUns  
!!    afe(), or Buffer.from() methods instead.                                     
!!    error Command failed with exit code 2.  
```


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
