### PR TITLE
EZP-32096: Provided possibility to configure icon sets per siteaccess

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": "^7.3",
         "ezsystems/ezplatform-kernel": "^1.2@dev",
+        "symfony/asset": "^5.0",
         "symfony/config": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/filesystem": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "autoload": {
         "psr-4": {
             "EzSystems\\EzPlatformCoreBundle\\": "src/EzPlatformCoreBundle/bundle/",
-            "EzSystems\\EzPlatformEncoreBundle\\": "src/EzPlatformEncoreBundle/bundle/"
+            "EzSystems\\EzPlatformEncoreBundle\\": "src/EzPlatformEncoreBundle/bundle/",
+            "Ibexa\\Platform\\Bundle\\Assets\\": "src/IbexaPlatformAssetsBundle/bundle/"
         }
     },
     "autoload-dev": {
@@ -22,6 +23,7 @@
     },
     "require": {
         "php": "^7.3",
+        "ezsystems/ezplatform-kernel": "^1.2@dev",
         "symfony/config": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/filesystem": "^5.0",

--- a/src/IbexaPlatformAssetsBundle/bundle/DependencyInjection/Configuration/Parser/Assets.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/DependencyInjection/Configuration/Parser/Assets.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\Assets\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class Assets extends AbstractParser
+{
+    private const ASSETS_NODE = 'assets';
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->arrayNode(self::ASSETS_NODE)
+                ->validate()
+                    ->ifTrue(function (array $assetsConfig): bool {
+                        return !isset($assetsConfig['icon_sets'][$assetsConfig['default_icon_set']]);
+                    })
+                    ->thenInvalid("Default Icon Set is not defined in 'icon_sets' configuration.")
+                ->end()
+                ->children()
+                    ->arrayNode('icon_sets')
+                        ->validate()
+                            ->ifTrue(function (array $value): bool {
+                                foreach ($value as $set => $path) {
+                                    $file = new \SplFileInfo($path);
+
+                                    if ($file->getExtension() !== 'svg') {
+                                        return true;
+                                    }
+                                }
+
+                                return false;
+                            })
+                            ->thenInvalid('Icon Path is invalid. Please provide *.svg file.')
+                        ->end()
+                        ->useAttributeAsKey('name')
+                        ->scalarPrototype()->end()
+                    ->end()
+                    ->scalarNode('default_icon_set')
+                        ->isRequired()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        if (empty($scopeSettings[self::ASSETS_NODE])) {
+            return;
+        }
+
+        foreach ($scopeSettings[self::ASSETS_NODE] as $identifier => $config) {
+            $contextualizer->setContextualParameter(sprintf('%s.%s', self::ASSETS_NODE, $identifier), $currentScope, $config);
+        }
+    }
+}

--- a/src/IbexaPlatformAssetsBundle/bundle/DependencyInjection/IbexaPlatformAssetsExtension.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/DependencyInjection/IbexaPlatformAssetsExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\Assets\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+final class IbexaPlatformAssetsExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config')
+        );
+
+        $loader->load('services.yaml');
+    }
+}

--- a/src/IbexaPlatformAssetsBundle/bundle/IbexaPlatformAssetsBundle.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/IbexaPlatformAssetsBundle.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\Assets;
+
+use Ibexa\Platform\Bundle\Assets\DependencyInjection\Configuration\Parser;
+use Ibexa\Platform\Bundle\Assets\DependencyInjection\IbexaPlatformAssetsExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class IbexaPlatformAssetsBundle extends Bundle
+{
+    public function getContainerExtension(): ExtensionInterface
+    {
+        return new IbexaPlatformAssetsExtension();
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $kernelExtension */
+        $kernelExtension = $container->getExtension('ezpublish');
+
+        $kernelExtension->addConfigParser(new Parser\Assets());
+    }
+}

--- a/src/IbexaPlatformAssetsBundle/bundle/Resources/config/services.yaml
+++ b/src/IbexaPlatformAssetsBundle/bundle/Resources/config/services.yaml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: services/twig.yaml }
+
+##
+## Keep this file empty.
+## For better organization put your services grouped in services/ directory.
+##

--- a/src/IbexaPlatformAssetsBundle/bundle/Resources/config/services/twig.yaml
+++ b/src/IbexaPlatformAssetsBundle/bundle/Resources/config/services/twig.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+        public: false
+
+    Ibexa\Platform\Bundle\Assets\Twig\Extension\IconSetExtension: ~

--- a/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Platform\Bundle\Assets\Twig\Extension;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use Symfony\Component\Asset\PackageInterface;
+use Symfony\Component\Asset\Packages;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -18,15 +18,15 @@ class IconSetExtension extends AbstractExtension
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \Symfony\Component\Asset\PackageInterface */
-    private $package;
+    /** @var \Symfony\Component\Asset\Packages */
+    private $packages;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
-        PackageInterface $package
+        Packages $packages
     ) {
         $this->configResolver = $configResolver;
-        $this->package = $package;
+        $this->packages = $packages;
     }
 
     public function getFunctions(): array
@@ -47,6 +47,6 @@ class IconSetExtension extends AbstractExtension
         $iconSetName = $set ?? $this->configResolver->getParameter('assets.default_icon_set');
         $iconSets = $this->configResolver->getParameter('assets.icon_sets');
 
-        return sprintf('%s#%s', $this->package->getUrl($iconSets[$iconSetName]), $icon);
+        return sprintf('%s#%s', $this->packages->getUrl($iconSets[$iconSetName]), $icon);
     }
 }

--- a/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Platform\Bundle\Assets\Twig\Extension;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Symfony\Component\Asset\PackageInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -17,9 +18,15 @@ class IconSetExtension extends AbstractExtension
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    public function __construct(ConfigResolverInterface $configResolver)
-    {
+    /** @var \Symfony\Component\Asset\PackageInterface */
+    private $package;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        PackageInterface $package
+    ) {
         $this->configResolver = $configResolver;
+        $this->package = $package;
     }
 
     public function getFunctions(): array
@@ -40,6 +47,6 @@ class IconSetExtension extends AbstractExtension
         $iconSetName = $set ?? $this->configResolver->getParameter('assets.default_icon_set');
         $iconSets = $this->configResolver->getParameter('assets.icon_sets');
 
-        return sprintf('%s#%s', $iconSets[$iconSetName], $icon);
+        return sprintf('%s#%s', $this->package->getUrl($iconSets[$iconSetName]), $icon);
     }
 }

--- a/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\Assets\Twig\Extension;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class IconSetExtension extends AbstractExtension
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ez_icon_path',
+                [$this, 'getIconPath'],
+                [
+                    'is_safe' => ['html'],
+                ]
+            ),
+        ];
+    }
+
+    public function getIconPath(string $icon, string $set = null): string
+    {
+        $iconSetName = $set ?? $this->configResolver->getParameter('assets.default_icon_set');
+        $iconSets = $this->configResolver->getParameter('assets.icon_sets');
+
+        return sprintf('%s#%s', $iconSets[$iconSetName], $icon);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32096](https://jira.ez.no/browse/EZP-32096)
| **Improvement**| yes
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

# Description
This PR adds new bundle `IbexaPlatformAssetsBundle` which comes with SA-aware configuration and new Twig helper. Configuration is simple:
```yaml
ezplatform:
    system:
        my_siteaccess:
            assets:
                icon_sets: 
                    webalys_streamline: /bundles/ezplatformadminuiassets/vendors/webalys/streamlineicons/all-icons.svg
                default_icon_set: webalys_streamline
```

You can define as many icon sets as you want. To generate icon path you can use new Twig helper `ez_icon_path(icon, icon_set)`. In order to get icon path for icon `edit` you can use `{{ ez_icon_path('edit') }}`. There is second argument allows to explicitly use one of the icon sets: `{{ ez_icon_path('edit', 'webalys_streamline') }}`.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
