### PR TITLE
EZP-32214: Refactored config/packages/overrides/* as Compiler Passes

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/GenericConfigPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/GenericConfigPass.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+
+class GenericConfigPass implements CompilerPassInterface
+{
+    /**
+     * On Symfony container compilation*, reads parameters from env variables if defined and overrides the yml parameters.
+     * For typical use cases like Docker, make sure to recompile Symfony container on run to refresh settings.
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $projectDir = $container->getParameter('kernel.project_dir');
+
+        if ($dfsNfsPath = $_SERVER['DFS_NFS_PATH'] ?? false) {
+            $container->setParameter('dfs_nfs_path', $dfsNfsPath);
+
+            $parameterMap = [
+                'dfs_database_charset' => 'database_charset',
+                'dfs_database_driver' => 'database_driver',
+                'dfs_database_collation' => 'database_collation',
+            ];
+
+            foreach ($parameterMap as $dfsParameter => $platformParameter) {
+                $container->setParameter(
+                    $dfsParameter,
+                    $_SERVER[strtoupper($dfsParameter)] ?? $container->getParameter($platformParameter)
+                );
+            }
+
+            $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/dfs'));
+            $loader->load('dfs.yaml');
+        }
+
+        // Cache settings
+        // If CACHE_POOL env variable is set, check if there is a yml file that needs to be loaded for it
+        if (($pool = $_SERVER['CACHE_POOL'] ?? false) && file_exists($projectDir . "/config/packages/cache_pool/${pool}.yaml")) {
+            $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
+            $loader->load($pool . '.yaml');
+        }
+
+        // Params that needs to be set at compile time and thus can't use Symfony's env()
+        if ($purgeType = $_SERVER['HTTPCACHE_PURGE_TYPE'] ?? false) {
+            $container->setParameter('purge_type', $purgeType);
+        }
+
+        if ($value = $_SERVER['MAILER_TRANSPORT'] ?? false) {
+            $container->setParameter('mailer_transport', $value);
+        }
+
+        if ($value = $_SERVER['LOG_TYPE'] ?? false) {
+            $container->setParameter('log_type', $value);
+        }
+
+        if ($value = $_SERVER['SESSION_HANDLER_ID'] ?? false) {
+            $container->setParameter('ezplatform.session.handler_id', $value);
+        }
+
+        if ($value = $_SERVER['SESSION_SAVE_PATH'] ?? false) {
+            $container->setParameter('ezplatform.session.save_path', $value);
+        }
+    }
+}

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/PlatformShConfigPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/PlatformShConfigPass.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+
+class PlatformShConfigPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $projectDir = $container->getParameter('kernel.project_dir');
+
+        // Run for all hooks, incl build step
+        if ($_SERVER['PLATFORM_PROJECT_ENTROPY'] ?? false) {
+            // Disable PHPStormPass as we don't have write access & it's not localhost
+            $container->setParameter('ezdesign.phpstorm.enabled', false);
+        }
+
+        // Will not be executed on build step
+        $relationships = $_SERVER['PLATFORM_RELATIONSHIPS'] ?? false;
+        if (!$relationships) {
+            return;
+        }
+        $routes = $_SERVER['PLATFORM_ROUTES'];
+
+        $relationships = json_decode(base64_decode($relationships), true);
+        $routes = json_decode(base64_decode($routes), true);
+
+        // PLATFORMSH_DFS_NFS_PATH is different compared to DFS_NFS_PATH in the sense that it is relative to ezplatform dir
+        // DFS_NFS_PATH is an absolute path
+        if ($dfsNfsPath = $_SERVER['PLATFORMSH_DFS_NFS_PATH'] ?? false) {
+            $container->setParameter('dfs_nfs_path', sprintf('%s/%s', $container->getParameter('kernel.project_dir'), $dfsNfsPath));
+
+            // Map common parameters
+            $container->setParameter('dfs_database_charset', $container->getParameter('database_charset'));
+            $container->setParameter(
+                'dfs_database_collation',
+                $container->getParameter('database_collation')
+            );
+            if (\array_key_exists('dfs_database', $relationships)) {
+                // process dedicated P.sh dedicated config
+                foreach ($relationships['dfs_database'] as $endpoint) {
+                    if (empty($endpoint['query']['is_master'])) {
+                        continue;
+                    }
+                    $container->setParameter('dfs_database_driver', 'pdo_' . $endpoint['scheme']);
+                    $container->setParameter(
+                        'dfs_database_url',
+                        sprintf(
+                            '%s://%s:%s:%d@%s/%s',
+                            $endpoint['scheme'],
+                            $endpoint['username'],
+                            $endpoint['password'],
+                            $endpoint['port'],
+                            $endpoint['host'],
+                            $endpoint['path']
+                        )
+                    );
+                }
+            } else {
+                // or set fallback from the Repository database, if not configured
+                $container->setParameter('dfs_database_driver', $container->getParameter('database_driver'));
+            }
+
+            $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/dfs'));
+            $loader->load('dfs.yaml');
+        }
+        // Use Redis-based caching if possible.
+        if (isset($relationships['rediscache'])) {
+            foreach ($relationships['rediscache'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'redis') {
+                    continue;
+                }
+
+                $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
+                $loader->load('cache.redis.yaml');
+
+                $container->setParameter('cache_pool', 'cache.redis');
+                $container->setParameter('cache_dsn', sprintf('%s:%d', $endpoint['host'], $endpoint['port']) . '?retry_interval=3');
+            }
+        } elseif (isset($relationships['cache'])) {
+            // Fallback to memcached if here (deprecated, we will only handle redis here in the future)
+            foreach ($relationships['cache'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'memcached') {
+                    continue;
+                }
+
+                @trigger_error('Usage of Memcached is deprecated, redis is recommended', E_USER_DEPRECATED);
+
+                $container->setParameter('cache_pool', 'cache.memcached');
+                $container->setParameter('cache_dsn', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+
+                $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
+                $loader->load('cache.memcached.yaml');
+            }
+        }
+
+        // Use Redis-based sessions if possible. If a separate Redis instance
+        // is available, use that.  If not, share a Redis instance with the
+        // Cache.  (That should be safe to do except on especially high-traffic sites.)
+        if (isset($relationships['redissession'])) {
+            foreach ($relationships['redissession'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'redis') {
+                    continue;
+                }
+
+                $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
+                $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+            }
+        } elseif (isset($relationships['rediscache'])) {
+            foreach ($relationships['rediscache'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'redis') {
+                    continue;
+                }
+
+                $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
+                $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+            }
+        }
+
+        if (isset($relationships['solr'])) {
+            foreach ($relationships['solr'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'solr') {
+                    continue;
+                }
+
+                $container->setParameter('search_engine', 'solr');
+                $container->setParameter('solr_dsn', sprintf('http://%s:%d/%s', $endpoint['host'], $endpoint['port'], 'solr'));
+                // To set solr_core parameter we assume path is in form like: "solr/collection1"
+                $container->setParameter('solr_core', substr($endpoint['path'], 5));
+            }
+        }
+
+        // We will pick a varnish route by the following prioritization:
+        // - The first route found that has upstream: varnish
+        // - if primary route has upstream: varnish, that route will be prioritised
+        // If no route is found with upstream: varnish, then purge_server will not be set
+        $route = null;
+        foreach ($routes as $host => $info) {
+            if ($route === null && $info['type'] === 'upstream' && $info['upstream'] === 'varnish') {
+                $route = $host;
+            }
+            if ($info['type'] === 'upstream' && $info['upstream'] === 'varnish' && $info['primary'] === true) {
+                $route = $host;
+                break;
+            }
+        }
+
+        if ($route !== null && !($_SERVER['HTTPCACHE_PURGE_TYPE'] ?? false)) {
+            $purgeServer = rtrim($route, '/');
+            if (($_SERVER['HTTPCACHE_USERNAME'] ?? false) && ($_SERVER['HTTPCACHE_PASSWORD'] ?? false)) {
+                $domain = parse_url($purgeServer, \PHP_URL_HOST);
+                $credentials = urlencode($_SERVER['HTTPCACHE_USERNAME']) . ':' . urlencode($_SERVER['HTTPCACHE_PASSWORD']);
+                $purgeServer = str_replace($domain, $credentials . '@' . $domain, $purgeServer);
+            }
+
+            $container->setParameter('purge_type', 'varnish');
+            $container->setParameter('purge_server', $purgeServer);
+        }
+        // Setting default value for HTTPCACHE_VARNISH_INVALIDATE_TOKEN if it is not explicitly set
+        if (!($_SERVER['HTTPCACHE_VARNISH_INVALIDATE_TOKEN'] ?? false)) {
+            $container->setParameter('varnish_invalidate_token', $_SERVER['PLATFORM_PROJECT_ENTROPY']);
+        }
+
+        // Adapt config based on enabled PHP extensions
+        // Get imagine to use imagick if enabled, to avoid using php memory for image conversions
+        if (\extension_loaded('imagick')) {
+            $container->setParameter('liip_imagine_driver', 'imagick');
+        }
+    }
+}

--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -8,7 +8,11 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformCoreBundle;
 
+use EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler\GenericConfigPass;
+use EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler\PlatformShConfigPass;
 use EzSystems\EzPlatformCoreBundle\DependencyInjection\EzPlatformCoreExtension;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,5 +26,13 @@ final class EzPlatformCoreBundle extends Bundle
     public function getContainerExtension(): ExtensionInterface
     {
         return new EzPlatformCoreExtension();
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new GenericConfigPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 255);
+        $container->addCompilerPass(new PlatformShConfigPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 250);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32214](https://jira.ez.no/browse/EZP-32214)
| **New feature**    | yes
| **Target version** |`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

In order to make `config/packages/overrides/{platformsh.php,generic.php}` files work we had to update `src/Kernel.php`. This is a problem for flex based applications as installing recipes doesn't allow to override existing files. This means on new installations we won't be able to use our configuration for P.sh, Cache, DFS etc. 

This was not a good solution from the beginning as we basically injected custom logic into configuration files. This should be handled by a Compiler Pass.

Complementary PR: https://github.com/ezsystems/ezplatform/pull/626
