### PR TITLE
EZP-32254: [platform.sh] http cache purge type disabled during deploy

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -318,7 +318,7 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
             }
         }
 
-        if ($route !== null) {
+        if ($route !== null && !($_SERVER['PLATFORMSH_DISABLE_HTTPCACHE_PURGE'] ?? false)) {
             $purgeServer = rtrim($route, '/');
             if (($_SERVER['HTTPCACHE_USERNAME'] ?? false) && ($_SERVER['HTTPCACHE_PASSWORD'] ?? false)) {
                 $domain = parse_url($purgeServer, PHP_URL_HOST);

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -318,7 +318,7 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
             }
         }
 
-        if ($route !== null && !($_SERVER['PLATFORMSH_DISABLE_HTTPCACHE_PURGE'] ?? false)) {
+        if ($route !== null && !($_SERVER['PLATFORMSH_SKIP_HTTPCACHE_PURGE'] ?? false)) {
             $purgeServer = rtrim($route, '/');
             if (($_SERVER['HTTPCACHE_USERNAME'] ?? false) && ($_SERVER['HTTPCACHE_PASSWORD'] ?? false)) {
                 $domain = parse_url($purgeServer, PHP_URL_HOST);


### PR DESCRIPTION
EZP-32254: [platform.sh] http cache purge type disabled during deploy

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32254](https://issues.ibexa.co/browse/EZP-32254)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

[Platform.sh] HTTPCACHE purge type should be disabled during deploy
