### PR TITLE
EZP-32277: Added support for setting up Trusted Proxies via ENVs or symfony semantic configuration

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpFoundation\Request;
 
 final class EzPlatformCoreExtension extends Extension implements PrependExtensionInterface
 {
@@ -148,8 +149,12 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
             $container->setParameter('ezplatform.session.save_path', $value);
         }
 
-        if (!$container->hasParameter('kernel.trusted_proxies') && $value = $_SERVER['TRUSTED_PROXIES'] ?? false) {
+        if (!$container->hasParameter('kernel.trusted_proxies')
+            && !$container->hasParameter('kernel.trusted_headers')
+            && $value = $_SERVER['TRUSTED_PROXIES'] ?? false
+        ) {
             $container->setParameter('kernel.trusted_proxies', $value);
+            $container->setParameter('kernel.trusted_headers', Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
         }
 
         if (!$container->hasParameter('kernel.trusted_hosts') && $value = $_SERVER['TRUSTED_HOSTS'] ?? false) {

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -151,6 +151,10 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
         if (!$container->hasParameter('kernel.trusted_proxies') && $value = $_SERVER['TRUSTED_PROXIES'] ?? false) {
             $container->setParameter('kernel.trusted_proxies', $value);
         }
+
+        if (!$container->hasParameter('kernel.trusted_hosts') && $value = $_SERVER['TRUSTED_HOSTS'] ?? false) {
+            $container->setParameter('kernel.trusted_hosts', $value);
+        }
     }
 
     private function configurePlatformShSetup(ContainerBuilder $container): void

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -147,6 +147,10 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
         if ($value = $_SERVER['SESSION_SAVE_PATH'] ?? false) {
             $container->setParameter('ezplatform.session.save_path', $value);
         }
+
+        if (!$container->hasParameter('kernel.trusted_proxies') && $value = $_SERVER['TRUSTED_PROXIES'] ?? false) {
+            $container->setParameter('kernel.trusted_proxies', $value);
+        }
     }
 
     private function configurePlatformShSetup(ContainerBuilder $container): void

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -149,6 +149,7 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
             $container->setParameter('ezplatform.session.save_path', $value);
         }
 
+        /** @Deprecated since 3.3, to be removed in 4.0, use symfony semantic configuration instead of ENVs */
         if (!$container->hasParameter('kernel.trusted_proxies')
             && !$container->hasParameter('kernel.trusted_headers')
             && $value = $_SERVER['TRUSTED_PROXIES'] ?? false


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32277](https://jira.ez.no/browse/EZP-32277)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` (as it affects symfony 5.2 with flex only)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes, if deprecated

Trusted proxies/hosts/headers are now configurable via semantic configuration (https://github.com/symfony/symfony/pull/37357) and following part is gone from default `index.php` (https://github.com/ezsystems/ezplatform/blob/master/public/index.php#L16-L22).

This way we make sure that if someone is using only ENVs to cover those settings he is still good to go and we still cover situation when those setting are configured via symfony semantic config. (They have precedence over ours).

## deprecations

Tbh, I would really like to make setting those params from ENVS deprecated and relay on symfony configuration from 4.0. I understand that this would make deploying on p.sh a little more cumbersome as you would have to edit config file, but still I think thats gonna save us some headaches in future. 

Defaults also changed in 5.1 as `Request::HEADER_X_FORWARDED_ALL` is now deprecated. Should we update it to match current state?

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
