### PR TITLE
Bumped Ibexa version to v3.3.1

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -17,7 +17,7 @@ final class EzPlatformCoreBundle extends Bundle
     /**
      * Ibexa DXP Version.
      */
-    public const VERSION = '3.3.0';
+    public const VERSION = '3.3.1';
 
     public function getContainerExtension(): ExtensionInterface
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | Ibexa 3.3.1
| **BC breaks**      | no
| **Doc needed**     | no

Bumping VERSION constant to prepare for 3.3.1 release