### PR TITLE
IBX-422: Rebrand ez-icon to ibexa-icon - ez_icon_path ---> ibexa_icon_path

### DIFF
--- a/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
+++ b/src/IbexaPlatformAssetsBundle/bundle/Twig/Extension/IconSetExtension.php
@@ -30,6 +30,15 @@ class IconSetExtension extends AbstractExtension
                 [$this, 'getIconPath'],
                 [
                     'is_safe' => ['html'],
+                    'deprecated' => true,
+                    'alternative' => 'ibexa_icon_path',
+                ],
+            ),
+            new TwigFunction(
+                'ibexa_icon_path',
+                [$this, 'getIconPath'],
+                [
+                    'is_safe' => ['html'],
                 ]
             ),
         ];


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-422](https://issues.ibexa.co/browse/IBX-422)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | yes
| **Doc needed**                       | no
| License       | [TTL-2.0](https://github.com/ezsystems/ezplatform-connector-dam/blob/master/LICENSE)

Icons should be rebranded from ez to ibexa.

Main PR: https://github.com/ezsystems/ezplatform-page-builder/pull/760



**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
