### PR TITLE
IBX-570: Fixed respecting `ezplatform.session.*` parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "require-dev": {
         "ezsystems/ezplatform-code-style": "^1.0@dev",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "phpunit/phpunit": "^8.3.5"
+        "phpunit/phpunit": "^8.3.5",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.2"
     },
     "scripts": {
         "test": "phpunit -v -c phpunit.xml",

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -53,6 +53,13 @@ final class SessionConfigurationPass implements CompilerPassInterface
             } else {
                 $container->setAlias('session.handler', $handlerId);
             }
+
+            $container
+                ->getDefinition('session.storage.native')
+                ->replaceArgument(1, new Reference('session.handler'));
+            $container
+                ->getDefinition('session.storage.php_bridge')
+                ->replaceArgument(0, new Reference('session.handler'));
         }
 
         if (null !== $savePath) {

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Configures session handler based on `ezplatform.session.handler_id`
+ * and `ezplatform.session.save_path`.
+ *
+ * This ensures parameters have the highest priority and the configuration
+ * will be respected with default framework.yaml file.
+ */
+class SessionConfigurationPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $handlerId = $container->hasParameter('ezplatform.session.handler_id')
+            ? $container->getParameter('ezplatform.session.handler_id')
+            : null;
+
+        $savePath = $container->hasParameter('ezplatform.session.save_path')
+            ? $container->getParameter('ezplatform.session.save_path')
+            : null;
+
+        if (null !== $handlerId) {
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($handlerId, null, $usedEnvs);
+
+            // code below follows FrameworkExtension from symfony/framework-bundle
+            if ($usedEnvs || preg_match('#^[a-z]++://#', $handlerId)) {
+                $id = '.cache_connection.' . ContainerBuilder::hash($handlerId);
+
+                $container->getDefinition('session.abstract_handler')
+                    ->replaceArgument(
+                        0,
+                        $container->hasDefinition($id)
+                            ? new Reference($id)
+                            : $handlerId
+                    );
+
+                $container->setAlias('session.handler', 'session.abstract_handler');
+            } else {
+                $container->setAlias('session.handler', $handlerId);
+            }
+        }
+
+        if (null !== $savePath) {
+            $container->setParameter('session.save_path', $savePath);
+        }
+    }
+}

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -18,8 +18,10 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * This ensures parameters have the highest priority and the configuration
  * will be respected with default framework.yaml file.
+ *
+ * @internal
  */
-class SessionConfigurationPass implements CompilerPassInterface
+final class SessionConfigurationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
@@ -42,7 +44,7 @@ class SessionConfigurationPass implements CompilerPassInterface
                 $container->getDefinition('session.abstract_handler')
                     ->replaceArgument(
                         0,
-                        $container->hasDefinition($id)
+                        $container->has($id)
                             ? new Reference($id)
                             : $handlerId
                     );

--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformCoreBundle;
 
+use EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler\SessionConfigurationPass;
 use EzSystems\EzPlatformCoreBundle\DependencyInjection\EzPlatformCoreExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,5 +24,10 @@ final class EzPlatformCoreBundle extends Bundle
     public function getContainerExtension(): ExtensionInterface
     {
         return new EzPlatformCoreExtension();
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new SessionConfigurationPass());
     }
 }

--- a/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformCoreBundle\DependencyInjection\Compiler;
+
+use EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler\SessionConfigurationPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
+
+class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SessionConfigurationPass());
+    }
+
+    public function testCompile(): void
+    {
+        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
+        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
+        $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
+    }
+
+    public function testCompileWithDsn(): void
+    {
+        $dsn = 'redis://instance.local:1234';
+
+        $definition = new Definition(AbstractSessionHandler::class);
+        $definition->setFactory([SessionHandlerFactory::class, 'createHandler']);
+        $definition->setArguments([$dsn]);
+
+        $this->container->setDefinition('session.abstract_handler', $definition);
+        $this->container->setParameter('ezplatform.session.handler_id', $dsn);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('session.handler', 'session.abstract_handler');
+    }
+
+    public function testCompileWithNullValues(): void
+    {
+        $this->container->setParameter('ezplatform.session.handler_id', null);
+        $this->container->setParameter('ezplatform.session.save_path', null);
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('session.handler');
+        self::assertNotTrue($this->container->hasParameter('session.save_path'));
+    }
+}

--- a/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -12,6 +12,7 @@ use EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler\SessionConfigura
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
 
@@ -24,6 +25,14 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
     public function testCompile(): void
     {
+        $this->container->setDefinition(
+            'session.storage.native',
+            (new Definition())->setArguments([null, null, null])
+        );
+        $this->container->setDefinition(
+            'session.storage.php_bridge',
+            (new Definition())->setArguments([null, null])
+        );
         $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
         $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
 
@@ -31,6 +40,16 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
         $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
         $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.native',
+            1,
+            new Reference('session.handler')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.php_bridge',
+            0,
+            new Reference('session.handler')
+        );
     }
 
     public function testCompileWithDsn(): void
@@ -43,6 +62,14 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
         $this->container->setDefinition('session.abstract_handler', $definition);
         $this->container->setParameter('ezplatform.session.handler_id', $dsn);
+        $this->container->setDefinition(
+            'session.storage.native',
+            (new Definition())->setArguments([null, null, null])
+        );
+        $this->container->setDefinition(
+            'session.storage.php_bridge',
+            (new Definition())->setArguments([null, null])
+        );
 
         $this->compile();
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-570](https://issues.ibexa.co/browse/IBX-570)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `2.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This fixes IBX-570 where `ezplatform.session.*` parameters are not respected because our `framework` configration in `ezplatform.yaml` file is overwritten by `framework.yaml`. Since we can't really modify `framework.yaml` as it comes from Symfony, I just reconfigure session handler in compiler pass. Default behavior (=using `framework.yaml` configuration) can be still achieved by setting `ezplatform.session.*` params to `null`.

Here is the second PR which removes obsolete configuration from `ezplatform.yaml`: https://github.com/ibexa/recipes/pull/32


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
