### PR TITLE
IBX-570: Fixed dependency on session storage services

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -54,12 +54,17 @@ final class SessionConfigurationPass implements CompilerPassInterface
                 $container->setAlias('session.handler', $handlerId);
             }
 
-            $container
-                ->getDefinition('session.storage.native')
-                ->replaceArgument(1, new Reference('session.handler'));
-            $container
-                ->getDefinition('session.storage.php_bridge')
-                ->replaceArgument(0, new Reference('session.handler'));
+            if ($container->hasDefinition('session.storage.native')) {
+                $container
+                    ->getDefinition('session.storage.native')
+                    ->replaceArgument(1, new Reference('session.handler'));
+            }
+
+            if ($container->hasDefinition('session.storage.php_bridge')) {
+                $container
+                    ->getDefinition('session.storage.php_bridge')
+                    ->replaceArgument(0, new Reference('session.handler'));
+            }
         }
 
         if (null !== $savePath) {

--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -65,6 +65,18 @@ final class SessionConfigurationPass implements CompilerPassInterface
                     ->getDefinition('session.storage.php_bridge')
                     ->replaceArgument(0, new Reference('session.handler'));
             }
+
+            if ($container->hasDefinition('session.storage.factory.native')) {
+                $container
+                    ->getDefinition('session.storage.factory.native')
+                    ->replaceArgument(1, new Reference('session.handler'));
+            }
+
+            if ($container->hasDefinition('session.storage.factory.php_bridge')) {
+                $container
+                    ->getDefinition('session.storage.factory.php_bridge')
+                    ->replaceArgument(0, new Reference('session.handler'));
+            }
         }
 
         if (null !== $savePath) {

--- a/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -25,19 +25,40 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
     public function testCompilesWithoutStorageDefinitions(): void
     {
-        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
-        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
-
-        $this->compile();
-
-        $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
-        $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
+        $this->doCompile();
 
         $this->assertContainerBuilderNotHasService('session.storage.native');
         $this->assertContainerBuilderNotHasService('session.storage.php_bridge');
+        $this->assertContainerBuilderNotHasService('session.storage.factory.native');
+        $this->assertContainerBuilderNotHasService('session.storage.factory.php_bridge');
     }
 
-    public function testCompile(): void
+    public function testCompileUsingStorageFactory(): void
+    {
+        $this->container->setDefinition(
+            'session.storage.factory.native',
+            (new Definition())->setArguments([null, null, null])
+        );
+        $this->container->setDefinition(
+            'session.storage.factory.php_bridge',
+            (new Definition())->setArguments([null, null])
+        );
+
+        $this->doCompile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.factory.native',
+            1,
+            new Reference('session.handler')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.factory.php_bridge',
+            0,
+            new Reference('session.handler')
+        );
+    }
+
+    public function testCompileUsingStorage(): void
     {
         $this->container->setDefinition(
             'session.storage.native',
@@ -47,13 +68,9 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
             'session.storage.php_bridge',
             (new Definition())->setArguments([null, null])
         );
-        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
-        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
 
-        $this->compile();
+        $this->doCompile();
 
-        $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
-        $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'session.storage.native',
             1,
@@ -64,6 +81,17 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
             0,
             new Reference('session.handler')
         );
+    }
+
+    private function doCompile(): void
+    {
+        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
+        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
+        $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
     }
 
     public function testCompileWithDsn(): void

--- a/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -25,12 +25,12 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
     public function testCompilesWithoutStorageDefinitions(): void
     {
-        $this->doCompile();
-
         $this->assertContainerBuilderNotHasService('session.storage.native');
         $this->assertContainerBuilderNotHasService('session.storage.php_bridge');
         $this->assertContainerBuilderNotHasService('session.storage.factory.native');
         $this->assertContainerBuilderNotHasService('session.storage.factory.php_bridge');
+
+        $this->doCompile();
     }
 
     public function testCompileUsingStorageFactory(): void

--- a/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/EzPlatformCoreBundle/bundle/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -23,6 +23,20 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new SessionConfigurationPass());
     }
 
+    public function testCompilesWithoutStorageDefinitions(): void
+    {
+        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
+        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
+        $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
+
+        $this->assertContainerBuilderNotHasService('session.storage.native');
+        $this->assertContainerBuilderNotHasService('session.storage.php_bridge');
+    }
+
     public function testCompile(): void
     {
         $this->container->setDefinition(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-570](https://issues.ibexa.co/browse/IBX-570)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `2.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for #40.

This PR removes the dependency on `session.storage.native` and `session.storage.php_bridge` service definitions.

Specifically, those two services do not exist in the test environment for Symfony framework (instead possibly being replaced with their mock variants (see https://symfony.com/doc/current/components/http_foundation/session_testing.html, or not used at all - when SecurityBundle is not loaded).

See https://github.com/ibexa/product-catalog/runs/2930845606?check_suite_focus=true and https://github.com/ibexa/product-catalog/runs/2929836113?check_suite_focus=true for test failures.

Blocks product catalog tests.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
