### PR TITLE
IBX-1466: Deprecated EzPlatformCoreBundle::VERSION const

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
+++ b/src/EzPlatformCoreBundle/bundle/EzPlatformCoreBundle.php
@@ -18,6 +18,9 @@ final class EzPlatformCoreBundle extends Bundle
 {
     /**
      * Ibexa DXP Version.
+     *
+     * @deprecated since Ibexa 4.0, use {@see \Ibexa\Contracts\Core\Ibexa::VERSION} from
+     * <code>ibexa/core</code> package instead.
      */
     public const VERSION = '4.0.0';
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Part of [IBX-1466](https://issues.ibexa.co/browse/IBX-1466)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Deprecated `EzPlatformCoreBundle::VERSION` in favor of `\Ibexa\Contracts\Core\Ibexa::VERSION` introduced via ibexa/core#17.

The `master` branch here will be most likely deleted, so this PR is rather a formality.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
