### PR TITLE
IBX-1431: ezdesign.phpstorm.enabled is handeled in ezplatform-design-engine

### DIFF
--- a/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
+++ b/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php
@@ -172,12 +172,6 @@ final class EzPlatformCoreExtension extends Extension implements PrependExtensio
     {
         $projectDir = $container->getParameter('kernel.project_dir');
 
-        // Run for all hooks, incl build step
-        if ($_SERVER['PLATFORM_PROJECT_ENTROPY'] ?? false) {
-            // Disable PHPStormPass as we don't have write access & it's not localhost
-            $container->setParameter('ezdesign.phpstorm.enabled', false);
-        }
-
         // Will not be executed on build step
         $relationships = $_SERVER['PLATFORM_RELATIONSHIPS'] ?? false;
         if (!$relationships) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-1431](https://issues.ibexa.co/browse/IBX-1431)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      |  no
| **Tests pass**     | yes
| **Doc needed**     | no

Right now it is impossible to get Symfony env variables on the Platform.sh/Ibexa cloud:
```
APP_DEBUG=1 php bin/console debug:container --env-vars

In Filesystem.php line 654:
Unable to write to the "/app" directory.
```
It happens because `ezdesign.phpstorm.enabled` parameter value is `true` despite the fact that it should be `false` for Platform.sh:

1.  There are two packages that are manipulating `ezdesign.phpstorm.enabled`: `EzPlatformCoreExtension` and `EzPlatformDesignEngineExtension`. And `EzPlatformCoreExtension` is processed first.
2. https://github.com/ezsystems/ezplatform-core/blob/master/src/EzPlatformCoreBundle/bundle/DependencyInjection/EzPlatformCoreExtension.php#L176-L179 sets `ezdesign.phpstorm.enabled` to `false`.
3. https://github.com/ezsystems/ezplatform-design-engine/blob/master/bundle/DependencyInjection/EzPlatformDesignEngineExtension.php#L54 always updates `ezdesign.phpstorm.enabled` to `%kernel.debug%` that is default value.

Thats why `ezdesign.phpstorm.enabled` value is always `%kernel.debug%`, even on Platform.sh/Ibexa Cloud.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

Replaces https://github.com/ezsystems/ezplatform-core/pull/48