### PR TITLE
IBX-2817: Fixed missing cast to float for timeout option in ibexa:encore:compile command

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -55,7 +55,7 @@ class CompileAssetsCommand extends Command implements BackwardCompatibleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $timeout = $input->getOption('timeout');
+        $timeout = (float)$input->getOption('timeout');
         $env = $input->getOption('env');
         $configName = $input->getOption('config-name');
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-2817](https://issues.ibexa.co/browse/IBX-2817)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
